### PR TITLE
✨ [add] ch.11 : 다형성

### DIFF
--- a/ch 11. 다형성1/sourceCODE/.gitignore
+++ b/ch 11. 다형성1/sourceCODE/.gitignore
@@ -1,0 +1,29 @@
+### IntelliJ IDEA ###
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/ch 11. 다형성1/sourceCODE/sourceCODE.iml
+++ b/ch 11. 다형성1/sourceCODE/sourceCODE.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/ch 11. 다형성1/sourceCODE/src/poly/basic/CastingMain1.java
+++ b/ch 11. 다형성1/sourceCODE/src/poly/basic/CastingMain1.java
@@ -1,0 +1,14 @@
+package poly.basic;
+
+public class CastingMain1 {
+    public static void main(String[] args) {
+
+        // 부모 변수에 자식 인스턴스 참조(다형적 참조)
+        Parent poly = new Child();
+        //poly.childMethod(); // 단 자식의 기능은 호출할 수 없다
+
+        // 이때 다운캐스팅(부모 타입 -> 자식 타입)이란 방법을 사용한다
+        Child child = (Child) poly;
+        child.childMethod(); // 이제는 자식의 기능을 호출할 수 있다
+    }
+}

--- a/ch 11. 다형성1/sourceCODE/src/poly/basic/CastingMain2.java
+++ b/ch 11. 다형성1/sourceCODE/src/poly/basic/CastingMain2.java
@@ -1,0 +1,12 @@
+package poly.basic;
+
+public class CastingMain2 {
+    public static void main(String[] args) {
+        // 부모 변수에 자식 인스턴스 참조(다형적 참조)
+        Parent poly = new Child();
+        //poly.childMethod(); // 단 자식의 기능은 호출할 수 없다
+
+        // 일시적 다운캐스팅 - 해당 메서드를 호출하는 순간만 다운캐스팅
+        ((Child) poly).childMethod();
+    }
+}

--- a/ch 11. 다형성1/sourceCODE/src/poly/basic/CastingMain3.java
+++ b/ch 11. 다형성1/sourceCODE/src/poly/basic/CastingMain3.java
@@ -1,0 +1,13 @@
+package poly.basic;
+
+// upcasting vs downcasting
+public class CastingMain3 {
+    public static void main(String[] args) {
+        Child child = new Child();
+        Parent parent1 = (Parent) child; //업캐스팅은 생략 가능, 생략 권장
+        Parent parent2 = child; //업캐스팅 생략
+
+        parent1.parentMethod();
+        parent2.parentMethod();
+    }
+}

--- a/ch 11. 다형성1/sourceCODE/src/poly/basic/CastingMain4.java
+++ b/ch 11. 다형성1/sourceCODE/src/poly/basic/CastingMain4.java
@@ -1,0 +1,13 @@
+package poly.basic;
+
+public class CastingMain4 {
+    public static void main(String[] args) {
+        Parent parent1 = new Child();
+        Child child1 = (Child) parent1;
+        child1.childMethod(); // 문제 없음
+
+        Parent parent2 = new Parent();
+        Child child2 = (Child) parent2; // 런타임 오류 - ClassCastException
+        child2.childMethod(); // 실행 불가
+    }
+}

--- a/ch 11. 다형성1/sourceCODE/src/poly/basic/CastingMain5.java
+++ b/ch 11. 다형성1/sourceCODE/src/poly/basic/CastingMain5.java
@@ -1,0 +1,25 @@
+package poly.basic;
+
+public class CastingMain5 {
+
+    public static void main(String[] args) {
+        Parent parent1 = new Parent(); // 다운캐스팅 불가
+        System.out.println("parent1 호출");
+        call(parent1);
+
+        Parent parent2 = new Child(); // 다운캐스팅 가능
+        System.out.println("parent2 호출");
+        call(parent2);
+    }
+
+    // childMethod()를 호출하고 싶어 ~
+    public static void call(Parent parent) {
+        if (parent instanceof Child) {
+            System.out.println("Child 인스턴스 맞음");
+            Child child = (Child) parent;
+            child.childMethod();
+        } else {
+            parent.parentMethod();
+        }
+    }
+}

--- a/ch 11. 다형성1/sourceCODE/src/poly/basic/CastingMain6.java
+++ b/ch 11. 다형성1/sourceCODE/src/poly/basic/CastingMain6.java
@@ -1,0 +1,23 @@
+package poly.basic;
+
+public class CastingMain6 {
+
+    public static void main(String[] args) {
+        Parent parent1 = new Parent();
+        System.out.println("parent1 호출");
+        call(parent1);
+
+        Parent parent2 = new Child();
+        System.out.println("parent2 호출");
+        call(parent2);
+    }
+
+    public static void call(Parent parent) {
+        if (parent instanceof Child child) {
+            System.out.println("Child 인스턴스 맞음");
+            child.childMethod();
+        } else {
+            parent.parentMethod();
+        }
+    }
+}

--- a/ch 11. 다형성1/sourceCODE/src/poly/basic/Child.java
+++ b/ch 11. 다형성1/sourceCODE/src/poly/basic/Child.java
@@ -1,0 +1,7 @@
+package poly.basic;
+
+public class Child extends Parent {
+    public void childMethod() {
+        System.out.println("Child.childMethod");
+    }
+}

--- a/ch 11. 다형성1/sourceCODE/src/poly/basic/Parent.java
+++ b/ch 11. 다형성1/sourceCODE/src/poly/basic/Parent.java
@@ -1,0 +1,7 @@
+package poly.basic;
+
+public class Parent {
+    public void parentMethod() {
+        System.out.println("Parent.parentMethod");
+    }
+}

--- a/ch 11. 다형성1/sourceCODE/src/poly/basic/PolyMain.java
+++ b/ch 11. 다형성1/sourceCODE/src/poly/basic/PolyMain.java
@@ -1,0 +1,24 @@
+package poly.basic;
+
+public class PolyMain {
+    public static void main(String[] args) {
+        // 부모 변수에 부모 인스턴스 참조값
+        System.out.println("Parent -> Parent");
+        Parent parent = new Parent();
+        parent.parentMethod();
+
+        // 자식 변수에 자식 인스턴스 참조값
+        System.out.println("Child -> Child");
+        Child child = new Child();
+        child.parentMethod();
+        child.childMethod();
+
+        // 부모 변수에 자식 인스턴스 참조값 (다형적 참조)
+        System.out.println("Parent -> Child");
+        Parent poly = new Child();
+        poly.parentMethod();
+        //poly.childMethod(); // 자식의 기능은 호출할 수 없다
+
+        //Child child1 = new Parent(); // 자식은 부모를 담을 수 없다
+    }
+}

--- a/ch 11. 다형성1/sourceCODE/src/poly/overriding/Child.java
+++ b/ch 11. 다형성1/sourceCODE/src/poly/overriding/Child.java
@@ -1,0 +1,11 @@
+package poly.overriding;
+
+public class Child extends Parent {
+
+    public String value = "child";
+
+    @Override
+    public void method() {
+        System.out.println("Child.method");
+    }
+}

--- a/ch 11. 다형성1/sourceCODE/src/poly/overriding/OverridingMain.java
+++ b/ch 11. 다형성1/sourceCODE/src/poly/overriding/OverridingMain.java
@@ -1,0 +1,24 @@
+package poly.overriding;
+
+public class OverridingMain {
+    public static void main(String[] args) {
+
+        // 자식 변수에 자식 인스턴스 참조값
+        Child child = new Child();
+        System.out.println("Child -> Child");
+        System.out.println("Value = " + child.value);
+        child.method();
+
+        // 부모 변수에 부모 인스턴스 참조값
+        Parent parent = new Parent();
+        System.out.println("Parent -> Parent");
+        System.out.println("Value = " + parent.value);
+        parent.method();
+
+        // 부모 변수에 자식 인스턴스 참조값(다형적 참조)
+        Parent poly = new Child();
+        System.out.println("Parent -> Child");
+        System.out.println("Value = " + poly.value); // 변수는 오버라이딩 x
+        poly.method(); // 메서드 오버라이딩
+    }
+}

--- a/ch 11. 다형성1/sourceCODE/src/poly/overriding/Parent.java
+++ b/ch 11. 다형성1/sourceCODE/src/poly/overriding/Parent.java
@@ -1,0 +1,10 @@
+package poly.overriding;
+
+public class Parent {
+
+    public String value = "parent";
+
+    public void method() {
+        System.out.println("Parent.method");
+    }
+}


### PR DESCRIPTION
## **🎭 다형성 🎭**
> 객체지향 프로그래밍의 꽃, **다형성** 🌹

> **한 객체가 여러 타입의 객체로 취급될 수 있는 능력**

#### **<다형적 참조>**
> 자신을 기준으로 모든 자식 타입을 참조할 수 있다
- 자식은 부모를 품을 수 없다
  - `Child child = new Parent();` 🚫
- 부모는 자식을 품을 수 있다
  - `Parent poly = new Child();`
- 다형적 참조를 하더라도, 자식의 기능은 호출할 수 없다
  - `poly.childMethod();` 🚫

#### **<캐스팅>**
> 자식의 기능을 호출하고 싶다면, 캐스팅해라 🕹️

##### **1️⃣ 다운캐스팅**
- `Parent poly = new Child();` 일 때,
- `Child child = (Child) poly`
- 이렇게 다운캐스팅 할 수 있다
- `new Child()` 로 인스턴스를 생성하면 내부에 `Child`와 `Parent`가 모두 생성된다 + 생성된 인스턴스는 `Parent` 타입 변수인 `poly`에 담았다
- 이때 `Parent` 타입 변수인 `poly`를 `(Child)` 키워드를 통해 강제로 다운캐스팅하여, `Child` 타입 변수인 `child`에 담는 것이다
- 이렇게 하면 `child.childMethod()` 처럼 자식의 기능을 호출할 수 있게 된다

  **☠️☠️☠️ 꼭 알아야 할 것은 ❌ 캐스팅 = 타입 변경 ❌ 아니라는 것 !!!!! ☠️☠️☠️**
  **해당 참조값을 꺼내고 꺼낸 참조값이 `Child` 타입이 되는 것 !!!!!** 아래 사진 참고
  
![KakaoTalk_20241030_005029163](https://github.com/user-attachments/assets/482954c2-ca9d-4258-bed6-210919f9a2cb)

  - 다만 이렇게 다운캐스팅 결과를 변수에 담고 -> 기능을 사용하는 과정이 번거롭다면 **일시적 다운캐스팅**을 이용하자

##### **2️⃣ 일시적 다운캐스팅**
> 별도의 변수없이 인스턴스의 자식 타입의 기능 사용 가능
- `((Child) poly).childMethod();`
- 이렇게 `Child child` 선언 과정이 없다
- 참고로 연산자 우선순위로 인해 가장 바깥에 괄호 하나를 더 감싸줘야 한다

##### **3️⃣ 업캐스팅**
> 현재 타입을 부모 타입으로 변경하는 것으로, 자주 사용 !
- `Child child = new Child();` 일 때
- `Parent parent1 = (Parent) child;` 하면 되지만 업캐스팅을 생략이 가능하므로
- `Parent parent1 = child;` 이렇게도 가능하다


#### **<다운캐스팅의 주의점>🚨 아주 중요 🚨**
> **부모 타입 (자식 인스턴스 생성) => 🙆🏻‍♀️ 다운캐스팅 문제없어요**
> **부모 타입 (부모 인스턴스 생성) => 🙅🏻‍♀️ 다운캐스팅하면 `Runtime error`**

- **다운캐스팅 가능한 경우**
  - `Parent parent1 = new Child();`
  - `Child child1 = (Child) parent1;`
  - `child1.childMethod();`

- **다운캐스팅 불가능한 경우**
  - `Parent parent2 = new Parent();`
  - `Child child2 = (Child) parent2;` => `ClassCastException` ☠️
  - `child2.childMethod();` => 실행 불가

![KakaoTalk_20241030_010721645](https://github.com/user-attachments/assets/88b61331-991c-4ecd-aa6a-bd606c6f57ad)
![KakaoTalk_20241030_010745132](https://github.com/user-attachments/assets/b296325c-a199-4a79-b0e0-6377005a917a)

**⭐⭐⭐`new Child()` 가 호출되면 `Child`, `Parent` 인스턴스가 동시에 생성되지만, `new Parent` 는 `Parent`만 생성되고 `Child`는 생성되지 않기 때문이다**

#### **<`instanceof`>**

> `ClassCastException` 무서운데 다운캐스팅 전에 참조하는 인스턴스의 타입을 확인하고 싶어 ㅜ_ㅜ

- `parent instanceof Child`
  - `parent` 변수에 `Child` 인스턴스가 있다면, `true`
  - 즉, `parent` 변수가 `new Child()` 의 참조값을 담고 있다면 `Parent`, `Child` 모두 가지고 있기 때문에 `true`
  - 반면 `new Parent()`의 참조값을 담았다면 `Child`는 없기 때문에 `false`

- 자바 16부터 패치된 Pattern Matching for instanceof 는 변수 선언과 `instanceof` 사용을 동시에 가능하게 !
  - `parent instanceof Child child`

#### **<메서드 오버라이딩>**
> 핵심은 오버라이딩 된 메서드가 항상 우선 ❕

- 부모를 상속받은 자식 클래스에 메서드 오버라이딩이 있다면
- 호출 타입이 부모이고 부모 클래스에 호출하려는 메서드가 있더라도, 자식 클래스의 오버라이드된 메서드가 호출됨

### **[Summary]**
뇌터진다 뇌터져 🤯🤯🤯 우선 코드 많이 짜보면서 다형성에 익숙해질 필요가 있어보이고 다형적 참조의 특징, 다운캐스팅 주의점은 꼭 꼭 기억할것 ~~~ ㅠ
